### PR TITLE
Adding package.json so repo can be managed via Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "animated-headline",
+  "version": "1.0.0",
+  "description": "CSS animated headlines",
+  "main": "index.html",
+  "repository": "git@github.com:ridown/animated-headline.git",
+  "author": "CodyHouse",
+  "license": "MIT"
+}


### PR DESCRIPTION
Yarn v0.19.1 cannot add a repo without a `package.json` file in the repo.